### PR TITLE
Addition of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.21.3 AS build-stage
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code.
+COPY *.go ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o /tm-discovery
+
+FROM gcr.io/distroless/base-debian11 AS release-stage
+
+WORKDIR /
+
+COPY --from=build-stage /tm-discovery /tm-discovery
+
+USER nonroot:nonroot
+
+#Run
+ENTRYPOINT ["/tm-discovery"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This tool discovers TM RPCs and peer addresses on Tendermint/CometBFT networks b
 
 
 ## Usage
+### With local Go development environment
 
 [Install Go](https://go.dev/doc/install)
 
@@ -31,4 +32,12 @@ You can use the --state-sync flag to generate statesync config which will be pri
 
 ```
 ./tm-discover --state-sync
+```
+
+### With Docker
+```
+git clone https://github.com/Ed-Commodum/tm-discovery.git
+cd tm-discovery
+docker build . -t tm-discovery
+docker run -it tm-discovery
 ```


### PR DESCRIPTION
Addition of Dockerfile, so the RPC endpoints can be obtained without a golang development environment installed.